### PR TITLE
Fixed makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = src tests
 
-dist_doc_DATA = SPECS INSTALL.git
+dist_doc_DATA = SPECS INSTALL.md
 EXTRA_DIST = src/canon-lbp.drv ppd
 nodist_data_DATA = Makefile.in
 


### PR DESCRIPTION
See https://github.com/mounaiban/captdriver/pull/16
> make is returning with error because it cannot find INSTALL.git
> So changing to INSTALL.md