### PR TITLE
No -c99

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,4 +17,4 @@ rastertocapt_LDADD = $(CUPS_LIBS)
 
 nodist_data_DATA = Makefile.in
 
-AM_CFLAGS = -std=c99 -Wall -Wextra -pedantic $(CUPS_CFLAGS)
+AM_CFLAGS = -Wall -Wextra $(CUPS_CFLAGS)

--- a/src/std.h
+++ b/src/std.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#define _POSIX_C_SOURCE 199309L /* try removing this if build fails */
 
 #include <stdbool.h>
 #include <stddef.h>


### PR DESCRIPTION
When compiling with clang on FreeBSD, let's not pretend we do pure C99 with some POSIX.