### PR TITLE
Respect cups-config --ldflags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,10 @@ if test -z "${CUPS_CONFIG}"; then
     AC_MSG_FAILURE([CUPS library not found.])
 fi
 CUPS_CFLAGS="`${CUPS_CONFIG} --cflags`"
+CUPS_LDFLAGS="`${CUPS_CONFIG} --image --ldflags`"
 CUPS_LIBS="`${CUPS_CONFIG} --image --libs`"
 AC_SUBST(CUPS_CFLAGS)
+AC_SUBST(CUPS_LDFLAGS)
 AC_SUBST(CUPS_LIBS)
 
 AC_CONFIG_FILES([Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ rastertocapt_SOURCES = rastertocapt.c \
 
 rastertocapt_SOURCES += prn_lbp2900.c
 
-rastertocapt_LDADD = $(CUPS_LIBS)
+rastertocapt_LDADD = $(CUPS_LDFLAGS) $(CUPS_LIBS)
 
 nodist_data_DATA = Makefile.in
 


### PR DESCRIPTION
On FreeBSD:

$ cups-config --image --libs gives

-lcups

but we also need

$ cups-config --ldflags

-L/usr/local/lib